### PR TITLE
Pass context as a dict instead of RequestContext

### DIFF
--- a/scribbler/templatetags/scribbler_tags.py
+++ b/scribbler/templatetags/scribbler_tags.py
@@ -62,7 +62,7 @@ class ScribbleNode(template.Node):
             else:
                 scribble_template = template.Template(self.raw)
         scribble_context = build_scribble_context(scribble, context)
-        content = scribble_template.render(scribble_context, request)
+        content = scribble_template.render(scribble_context.flatten(), request)
         wrapper_template = template.loader.get_template('scribbler/scribble-wrapper.html')
         context['scribble'] = scribble
         context['rendered_scribble'] = content


### PR DESCRIPTION
Breaking change: https://docs.djangoproject.com/en/1.11/releases/1.11/#django-template-backends-django-template-render-prohibits-non-dict-context